### PR TITLE
feat: improve data view performance

### DIFF
--- a/src/templates/dataView.html
+++ b/src/templates/dataView.html
@@ -778,12 +778,39 @@
                         }
                         newData.forEach(row => {
                             const tr = document.createElement('tr');
-                            tr.innerHTML = row.map(cell => 
+                            tr.innerHTML = row.map(cell =>
                                 `<td class="cell-editable" tabindex="0" title="${escapeHtml(cell)}">${escapeHtml(cell)}</td>`
                             ).join('');
                             tableBody.appendChild(tr);
                         });
                         showNotification('Datos actualizados');
+                        break;
+                    }
+                    case 'updateRows': {
+                        message.updates.forEach(update => {
+                            const { start, deleteCount, rows } = update;
+                            for (let i = 0; i < deleteCount - rows.length; i++) {
+                                const toRemove = tableBody.children[start + rows.length];
+                                if (toRemove) {
+                                    tableBody.removeChild(toRemove);
+                                }
+                            }
+                            rows.forEach((row, index) => {
+                                const rowIndex = start + index;
+                                let tr = tableBody.children[rowIndex];
+                                if (!tr) {
+                                    tr = document.createElement('tr');
+                                    if (rowIndex >= tableBody.children.length) {
+                                        tableBody.appendChild(tr);
+                                    } else {
+                                        tableBody.insertBefore(tr, tableBody.children[rowIndex]);
+                                    }
+                                }
+                                tr.innerHTML = row.map(cell =>
+                                    `<td class="cell-editable" tabindex="0" title="${escapeHtml(cell)}">${escapeHtml(cell)}</td>`
+                                ).join('');
+                            });
+                        });
                         break;
                     }
                     case 'saveComplete': {


### PR DESCRIPTION
## Summary
- debounce ARFF view updates and reuse last parsed data
- incrementally update modified rows instead of reloading entire table

## Testing
- `npm run lint` *(fails: sonarjs/prefer-regexp-exec not found)*
- `npm run compile`
- `npm test` *(fails: Cannot find module out/test/runTest.js)*

------
https://chatgpt.com/codex/tasks/task_e_68955632c998832e813753d63e09e565